### PR TITLE
Add unit test (non-core modules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,11 +280,13 @@ Thank you for your interest in CloneLLM. We look forward to seeing what you'll c
 - [x] Rename `completion` methods to `invoke`
 - [x] Add support for streaming completion
 - [ ] Add support for custom system prompts
-- [ ] Add an attribute to return supported models
+- [x] Make `LiteLLMEmbeddings.all_embedding_models` a property
+- [ ] Add an attribute to `CloneLLM` to return supported models
 - [x] Add initial version of README
-- [ ] Describe `clear_memory` method in README
+- [ ] Describe `CloneLLM.clear_memory` method in README
 - [ ] Add documents
 - [ ] Add usage examples
-- [ ] Add initial unit tests
+- [x] Add unit tests for non-core modules
+- [ ] Add unit tests for core module
 - [x] Add GitHub workflow to run tests on PR
 - [x] Add GitHub workflow to publish to PyPI on release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ ruff = "^0.4"
 types-setuptools = "^69.0.0.20240106"
 
 [tool.mypy]
+exclude=["tests"]
 namespace_packages = false
 files = ["src/clonellm/**/*.py"]
 check_untyped_defs = true
@@ -42,6 +43,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 filterwarnings = ["ignore"]
 
 [tool.ruff]

--- a/src/clonellm/embed.py
+++ b/src/clonellm/embed.py
@@ -74,6 +74,7 @@ class LiteLLMEmbeddings(LiteLLMMixin, Embeddings):
         embeddings = await self.aembed_documents([text])
         return embeddings[0]
 
+    @property
     def all_embedding_models(self) -> list[str]:
         """
         Returns the names of supported embedding models.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from dotenv import load_dotenv
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _load_dotenv():
+    load_dotenv()

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,80 @@
+import random
+import string
+
+from litellm import (
+    azure_embedding_models,
+    cohere_embedding_models,
+    vertex_embedding_models,
+    bedrock_embedding_models,
+    open_ai_embedding_models,
+)
+import pytest
+
+from clonellm import LiteLLMEmbeddings
+
+API_KEY = "TEST_API_KEY"
+
+
+@pytest.mark.parametrize(
+    ("provider", "models"),
+    [
+        ("azure", azure_embedding_models),
+        ("cohere", cohere_embedding_models),
+        ("vertex_ai", vertex_embedding_models),
+        ("bedrock", bedrock_embedding_models),
+        ("openai", open_ai_embedding_models),
+    ],
+)
+def test_llm_provider(provider: str, models: list[str] | dict[str, str]):
+    models_ = list(models.values()) if isinstance(models, dict) else models
+    for model in models_:
+        assert LiteLLMEmbeddings(model)._llm_provider == provider
+
+
+def test_api_key():
+    embed = LiteLLMEmbeddings(model="gpt-4o")
+    assert isinstance(embed._api_key, str)
+    assert embed._api_key.startswith("sk-")
+
+
+def create_random_text(length: int = 20) -> str:
+    return "".join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits + " ", k=length))
+
+
+def test_embed_documents():
+    embed = LiteLLMEmbeddings(model="text-embedding-3-small")
+    documents = [create_random_text() for _ in range(10)]
+    embeddings = embed.embed_documents(documents)
+    assert isinstance(embeddings, list)
+    for item in embeddings:
+        assert isinstance(item, list)
+        for v in item:
+            isinstance(v, float)
+
+
+@pytest.mark.asyncio
+async def test_aembed_documents():
+    embed = LiteLLMEmbeddings(model="text-embedding-3-small")
+    documents = [create_random_text() for _ in range(10)]
+    embeddings = await embed.aembed_documents(documents)
+    assert isinstance(embeddings, list)
+    for item in embeddings:
+        assert isinstance(item, list)
+        for v in item:
+            isinstance(v, float)
+
+
+@pytest.mark.parametrize("dimensions", [256, 512])
+def test_embed_documents_with_dimensions(dimensions: int):
+    embed = LiteLLMEmbeddings(model="text-embedding-3-small", dimensions=dimensions)
+    documents = [create_random_text() for _ in range(10)]
+    embeddings = embed.embed_documents(documents)
+    for item in embeddings:
+        assert len(item) == dimensions
+
+
+def test_all_embedding_models():
+    embed = LiteLLMEmbeddings(model="text-embedding-3-small")
+    assert isinstance(embed.all_embedding_models, list)
+    for model in embed.all_embedding_models:
+        assert isinstance(model, str)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,53 @@
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+import clonellm.memory
+from clonellm.memory import InMemoryHistory, get_session_history, clear_session_history
+
+
+def test_history_add_message():
+    history = InMemoryHistory()
+    history.add_message(HumanMessage(content="Hello"))
+    assert len(history.messages)
+    assert history.messages == [HumanMessage(content="Hello")]
+
+
+def test_history_last_message():
+    history = InMemoryHistory(messages=[HumanMessage(content="one"), SystemMessage(content="two")])
+    assert history.messages[-1] == SystemMessage(content="two")
+
+
+def test_history_clear():
+    history = InMemoryHistory(messages=[HumanMessage(content="one"), SystemMessage(content="two")])
+    history.add_user_message("three")
+    assert len(history.messages) == 3
+    history.clear()
+    assert len(history.messages) == 0
+
+
+def test_get_session_history():
+    session_id = "123"
+    history = get_session_history(session_id)
+    assert isinstance(history, InMemoryHistory)
+    assert len(history.messages) == 0
+    assert len(clonellm.memory._store) == 1
+    assert session_id in clonellm.memory._store
+    history.add_ai_message("Hello")
+    assert len(get_session_history(session_id).messages) == 1
+    assert get_session_history(session_id).messages[0] == AIMessage(content="Hello")
+    _ = get_session_history("abc")
+    assert len(clonellm.memory._store) == 2
+    assert "abc" in clonellm.memory._store
+
+
+def test_clear_session_history():
+    clonellm.memory._store = {}
+    session_id = "123"
+    history = get_session_history(session_id)
+    history.add_user_message("Hello")
+    assert len(get_session_history(session_id).messages) == 1
+    _ = get_session_history("abc")
+    assert len(clonellm.memory._store) == 2
+    clear_session_history(session_id)
+    assert len(clonellm.memory._store) == 1
+    clear_session_history("abc")
+    assert len(clonellm.memory._store) == 0


### PR DESCRIPTION
- Add _tests/conftest.py_ script to load environment variables
- Add unit tests for the `embed` module
- Add unit tests for the `memory` module
- Make `LiteLLMEmbeddings.all_embedding_models` a property (it was a method)
- Exclude _tests/*_ for mypy