### PR TITLE
Add attribute to return memory size, fix requirements in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <h4 align="center">
     <a href="https://pypi.org/project/clonellm/" target="_blank">
-        <img src="https://img.shields.io/badge/release-v0.0.5-green" alt="Latest Release">
+        <img src="https://img.shields.io/badge/release-v0.0.6-green" alt="Latest Release">
     </a>
     <a href="https://pypi.org/project/clonellm/" target="_blank">
         <img src="https://img.shields.io/pypi/v/clonellm.svg" alt="PyPI Version">
@@ -200,6 +200,18 @@ clone = CloneLLM(
 )
 ```
 
+Use the `memory_size` attribute to get the length of conversation history, i.e., the size of clone memory:
+```
+print(clone.memory_size)
+# 6
+```
+
+If you needed to clear the history of the conversation, i.e., the clone memory, at any time, you can easily call either of the `reset_memory()` and `clear_memory()` methods.
+```python
+clone.clear_memory()
+# clone.reset_memory()
+```
+
 ### Streaming
 CloneLLM supports streaming responses from the LLM, allowing for real-time processing of text as it is being generated, rather than receiving the whole output at once.
 ```python
@@ -279,14 +291,15 @@ Thank you for your interest in CloneLLM. We look forward to seeing what you'll c
 - [x] Fix mypy errors
 - [x] Rename `completion` methods to `invoke`
 - [x] Add support for streaming completion
-- [ ] Add support for custom system prompts
 - [x] Make `LiteLLMEmbeddings.all_embedding_models` a property
 - [x] Add an attribute to `CloneLLM` to return supported models
 - [x] Add initial version of README
-- [ ] Describe `CloneLLM.clear_memory` method in README
+- [x] Describe `CloneLLM.clear_memory` method in README
+- [x] Add an attribute to `CloneLLM` to return the size of the memory
+- [ ] Add support for custom system prompts
 - [ ] Add documents
 - [x] Add usage examples
 - [x] Add unit tests for non-core modules
-- [ ] Add unit tests for core module
+- [x] Add unit tests for core module
 - [x] Add GitHub workflow to run tests on PR
 - [x] Add GitHub workflow to publish to PyPI on release

--- a/examples/advanced_clone.py
+++ b/examples/advanced_clone.py
@@ -8,6 +8,7 @@ from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
 
 RESET_MEMORY_COMMANDS = ["reset memory", "clear memory", "clear your memory", "forget everything"]
 EXIT_COMMANDS = ["exit", "quit"]
+MAX_MEMORY_SIZE = 20
 
 
 def main():
@@ -66,6 +67,11 @@ def main():
 
         for chunk in clone.stream(prompt):
             print(chunk, end="", flush=True)
+
+        if clone.memory_size >= MAX_MEMORY_SIZE:
+            clone.clear_memory()
+            print("\n[Memory is cleared]", end="")
+
         print("\n")
 
 

--- a/examples/advanced_clone_async.py
+++ b/examples/advanced_clone_async.py
@@ -9,6 +9,7 @@ from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
 
 RESET_MEMORY_COMMANDS = ["reset memory", "clear memory", "clear your memory", "forget everything"]
 EXIT_COMMANDS = ["exit", "quit"]
+MAX_MEMORY_SIZE = 20
 
 
 async def main():
@@ -67,6 +68,11 @@ async def main():
 
         async for chunk in clone.astream(prompt):
             print(chunk, end="", flush=True)
+
+        if clone.memory_size >= MAX_MEMORY_SIZE:
+            clone.clear_memory()
+            print("\n[Memory is cleared]", end="")
+
         print("\n")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "clonellm"
-version = "0.0.5"
+version = "0.0.6"
 description = "Python package to create an AI clone of yourself using LLMs."
 packages = [{ from = "src", include = "clonellm" }]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import setup, find_packages
 
 from clonellm import __version__
 
-requirements = [s.replace("\n", "").strip() for s in open("requirements.txt").read()]
-
+requirements = [s.replace("\n", "").strip() for s in open("requirements.txt").readlines()]
+requirements_dev = list({s.replace("\n", "").strip() for s in open("requirements_dev.txt").readlines()} - set(requirements))
 
 setup(
     name="clonellm",
@@ -35,5 +35,5 @@ setup(
     ],
     python_requires=">=3.9,<3.13",
     install_requires=requirements,
-    extras_require={"dev": ["pytest", "mypy", "pytest-asyncio", "ruff>=0.4,<0.5", "types-setuptools>=69.0.0.20240106,<70.0.0"]},
+    extras_require={"dev": requirements_dev},
 )

--- a/src/clonellm/__init__.py
+++ b/src/clonellm/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Mehdi Samsami"
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 from ._typing import UserProfile
 from .embed import LiteLLMEmbeddings

--- a/src/clonellm/memory.py
+++ b/src/clonellm/memory.py
@@ -6,7 +6,7 @@ from langchain_core.pydantic_v1 import BaseModel, Field
 
 _store = {}
 
-__all__ = ("InMemoryHistory", "get_session_history", "clear_session_history")
+__all__ = ("InMemoryHistory", "get_session_history", "get_session_history_size", "clear_session_history")
 
 
 class InMemoryHistory(BaseChatMessageHistory, BaseModel):
@@ -35,6 +35,12 @@ def get_session_history(session_id: str) -> InMemoryHistory:
     if session_id not in _store:
         _store[session_id] = InMemoryHistory()
     return _store[session_id]
+
+
+def get_session_history_size(session_id: str) -> int:
+    if session_id not in _store:
+        return 0
+    return len(_store[session_id].messages)
 
 
 def clear_session_history(session_id: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import random
 import string
 
+import clonellm.memory
+
 from dotenv import load_dotenv
 import pytest
 
@@ -14,3 +16,15 @@ def _load_dotenv():
 def random_text(request) -> str:
     length = request.param if hasattr(request, "param") and request.param else 20
     return "".join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits + " ", k=length))
+
+
+@pytest.fixture
+def clear_memory_store():
+    """Fixture to execute asserts before and after a test is run"""
+    # Setup
+    clonellm.memory._store = {}
+
+    yield
+
+    # Teardown
+    clonellm.memory._store = {}


### PR DESCRIPTION
- Add the `memory_size` attribute to `CloneLLM` to return the size/length of clone memory
- Raise error when calling fit/update methods without providing any documents
- Fix bug in gathering requirements in _setup.py_ file
- Update README
- Minor update in examples (advanced clone)