### PR TITLE
feat: In-memory vector store

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <h4 align="center">
     <a href="https://pypi.org/project/clonellm/" target="_blank">
-        <img src="https://img.shields.io/badge/release-v0.1.0-green" alt="Latest Release">
+        <img src="https://img.shields.io/badge/release-v0.2.0-green" alt="Latest Release">
     </a>
     <a href="https://pypi.org/project/clonellm/" target="_blank">
         <img src="https://img.shields.io/pypi/v/clonellm.svg" alt="PyPI Version">
@@ -158,15 +158,21 @@ clone = CloneLLM(model="gpt-4o-mini", documents=documents, embedding=embedding)
 ```
 
 #### Vector store
-Currently, CloneLLM supports [Chroma](https://github.com/chroma-core/chroma) and [FAISS](https://github.com/facebookresearch/faiss) vector stores (default is FAISS). When an embedding model is specified (via the `embedding` parameter), the dynamic context retrieval is enabled and the selected vector store will be initialized and used to store the document embeddings.
+Currently, CloneLLM supports the following vector stores:
+- [Chroma](https://github.com/chroma-core/chroma)
+- [FAISS](https://github.com/facebookresearch/faiss)
+- [InMemory](https://python.langchain.com/api_reference/core/vectorstores/langchain_core.vectorstores.in_memory.InMemoryVectorStore.html) (default)
+
+When an embedding model is specified (via the `embedding` parameter), the dynamic context retrieval is enabled and the selected vector store will be initialized and used to store the document embeddings.
 ```python
+# !pip install clonellm[faiss]
 from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore
 import os
 
 os.environ["OPENAI_API_KEY"] = "openai-api-key"
 
 embedding = LiteLLMEmbeddings(model="text-embedding-3-small")
-clone = CloneLLM(model="gpt-4o", documents=documents, embedding=embedding, vector_store=RagVectorStore.Chroma)
+clone = CloneLLM(model="gpt-4o", documents=documents, embedding=embedding, vector_store=RagVectorStore.FAISS)
 ```
 
 ### User profile
@@ -197,6 +203,7 @@ profile = {
 
 Finnaly:
 ```python
+# !pip install clonellm[chroma]
 from clonellm import CloneLLM
 import os
 
@@ -206,6 +213,7 @@ clone = CloneLLM(
     model="claude-3-opus-20240229",
     documents=documents,
     embedding=embedding,
+    vector_store=RagVectorStore.Chroma,
     user_profile=profile,
 )
 ```

--- a/examples/advanced_clone.py
+++ b/examples/advanced_clone.py
@@ -4,6 +4,7 @@ from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
 
 from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore, UserProfile
 
+# !pip install clonellm[chroma]
 # !pip install pypdf
 # !pip install unstructured
 

--- a/examples/advanced_clone_async.py
+++ b/examples/advanced_clone_async.py
@@ -5,6 +5,7 @@ from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
 
 from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore, UserProfile
 
+# !pip install clonellm[chroma]
 # !pip install pypdf
 # !pip install unstructured
 

--- a/examples/fit_and_update.py
+++ b/examples/fit_and_update.py
@@ -8,8 +8,9 @@ from langchain_community.document_loaders import (
 )
 from langchain_core.documents import Document
 
-from clonellm import CloneLLM, LiteLLMEmbeddings
+from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore
 
+# !pip install clonellm[faiss]
 # !pip install jq
 # !pip install pypdf
 # !pip install unstructured
@@ -26,7 +27,7 @@ def main():
     documents += PyPDFLoader("my_cv.pdf").load()
 
     embedding = LiteLLMEmbeddings(model="text-embedding-3-small")
-    clone = CloneLLM(model="gpt-4o", documents=documents, embedding=embedding)
+    clone = CloneLLM(model="gpt-4o-mini", documents=documents, embedding=embedding, vector_store=RagVectorStore.FAISS)
     clone.fit()
 
     new_documents = JSONLoader(file_path="chat.json", jq_schema=".messages[].content", text_content=False).load()

--- a/examples/fit_and_update_async.py
+++ b/examples/fit_and_update_async.py
@@ -10,8 +10,9 @@ from langchain_community.document_loaders import (
 )
 from langchain_core.documents import Document
 
-from clonellm import CloneLLM, LiteLLMEmbeddings
+from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore
 
+# !pip install clonellm[faiss]
 # !pip install jq
 # !pip install pypdf
 # !pip install unstructured
@@ -28,7 +29,7 @@ async def main():
     documents += await PyPDFLoader("my_cv.pdf").aload()
 
     embedding = LiteLLMEmbeddings(model="text-embedding-3-small")
-    clone = CloneLLM(model="gpt-4o", documents=documents, embedding=embedding)
+    clone = CloneLLM(model="gpt-4o-mini", documents=documents, embedding=embedding, vector_store=RagVectorStore.FAISS)
     await clone.afit()
 
     new_documents = await JSONLoader(file_path="chat.json", jq_schema=".messages[].content", text_content=False).aload()

--- a/examples/simple_clone_with_embedding.py
+++ b/examples/simple_clone_with_embedding.py
@@ -6,7 +6,7 @@ EXIT_COMMANDS = ["exit", "quit"]
 def main():
     documents = [open("about_me.txt").read()]
     embedding = LiteLLMEmbeddings(model="text-embedding-3-small")
-    clone = CloneLLM(model="gpt-3.5-turbo", documents=documents, embedding=embedding)
+    clone = CloneLLM(model="gpt-4o-mini", documents=documents, embedding=embedding)
     clone.fit()
 
     while True:

--- a/examples/simple_clone_with_embedding_async.py
+++ b/examples/simple_clone_with_embedding_async.py
@@ -8,7 +8,7 @@ EXIT_COMMANDS = ["exit", "quit"]
 async def main():
     documents = [open("about_me.txt").read()]
     embedding = LiteLLMEmbeddings(model="text-embedding-3-small")
-    clone = CloneLLM(model="gpt-3.5-turbo", documents=documents, embedding=embedding)
+    clone = CloneLLM(model="gpt-4o-mini", documents=documents, embedding=embedding)
     await clone.afit()
 
     while True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "clonellm"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python package to create an AI clone of yourself using LLMs."
 packages = [{ from = "src", include = "clonellm" }]
 include = ["src/clonellm/py.typed"]
 license = "MIT"
 authors = ["Mehdi Samsami <mehdisamsami@live.com>"]
 readme = "README.md"
-keywords = ["llm", "language models", "nlp", "rag", "ai", "ai clone"]
+keywords = ["python", "ai", "llm", "language models", "nlp", "rag", "clone"]
 repository = "https://github.com/msamsami/clonellm"
 
 [tool.poetry.dependencies]

--- a/src/clonellm/__init__.py
+++ b/src/clonellm/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Mehdi Samsami"
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from ._typing import UserProfile
 from .core import CloneLLM

--- a/src/clonellm/core.py
+++ b/src/clonellm/core.py
@@ -45,7 +45,7 @@ class CloneLLM(LiteLLMMixin):
         model (str): The name of the language model to use for text completion.
         documents (list[Document | str]): List of documents related to cloning user to use as context for the language model.
         embedding (Optional[Embeddings]): The embedding function to use for RAG. Defaults to None for no embedding, i.e., a summary of `documents` is used for RAG.
-        vector_store (Optional[str | RagVectorStore]): The vector store to use for embedding-based retrieval. Defaults to None for "inmemory" vector store.
+        vector_store (Optional[str | RagVectorStore]): The vector store to use for embedding-based retrieval. Defaults to None for "in-memory" vector store.
         user_profile (Optional[UserProfile | dict[str, Any] | str]): The profile of the user to be cloned by the language model. Defaults to None.
         memory (Optional[bool | int]): Maximum number of messages in conversation memory. Defaults to None (or 0) for no memory. -1 or `True` means infinite memory.
         api_key (Optional[str]): The API key to use. Defaults to None.

--- a/src/clonellm/enums.py
+++ b/src/clonellm/enums.py
@@ -4,4 +4,4 @@ from enum import Enum
 class RagVectorStore(str, Enum):
     Chroma = "chroma"
     FAISS = "faiss"
-    InMemory = "inmemory"
+    InMemory = "in-memory"

--- a/src/clonellm/enums.py
+++ b/src/clonellm/enums.py
@@ -4,3 +4,4 @@ from enum import Enum
 class RagVectorStore(str, Enum):
     Chroma = "chroma"
     FAISS = "faiss"
+    InMemory = "inmemory"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,12 +10,12 @@ from clonellm.memory import get_session_history
 
 LLM_MODEL = "gpt-4o-mini"
 LLM_SETTINGS = dict(temprature=0.1, max_tokens=32)
-EMBEDDING_MODEL = "text-embedding-3-small"
 GENERIC_PROFILE = dict(first_name="Mehdi", last_name="Samsami")
 GENERIC_CONTEXT = "I'm Mehdi Samsami."
 GENERIC_PROMPT = "What football team do you support?"
+EMBEDDING_MODEL = "text-embedding-3-small"
 embed = LiteLLMEmbeddings(model=EMBEDDING_MODEL)
-EMBEDDING_VECTOR_STORE_PARAMETRIZE = ("embedding", "vector_store"), [(None, None)] + [(embed, e) for e in RagVectorStore]
+EMBEDDING_VECTOR_STORE_PARAMETRIZE = ("embedding", "vector_store"), [(None, None)] + [(embed, vs) for vs in RagVectorStore]
 
 
 def test_api_key():
@@ -35,10 +35,11 @@ def test_internal_init(mock_find_spec):
     assert isinstance(clone._session_id, str)
 
 
-def test_internal_init_with_missing_dependencies(mock_find_spec):
+@pytest.mark.parametrize("vector_store", [vs for vs in RagVectorStore if vs != RagVectorStore.InMemory])
+def test_internal_init_with_missing_dependencies(vector_store, mock_find_spec):
     mock_find_spec.return_value = None
     with pytest.raises(ImportError, match="Could not import"):
-        CloneLLM(model=LLM_MODEL, documents=[], embedding=embed)
+        CloneLLM(model=LLM_MODEL, documents=[], embedding=embed, vector_store=vector_store)
 
 
 def test_internal_init_without_embedding():


### PR DESCRIPTION
- Add a new item to the `RagVectorStore` enum for the in-memory vector store: `RagVectorStore.InMemory`
- Add support for in-memory vector store in `CloneLLM` (based on LangChain's `InMemoryVectorStore`)
- Set default vector store of `CloneLLM` to in-memory vector store
- Minor update in README ("Vector store" section)
- Minor update in examples
- Bump version to 0.2.0