### PR TITLE
fix: add `faiss` to extras in _setup.py_, add more type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <h4 align="center">
     <a href="https://pypi.org/project/clonellm/" target="_blank">
-        <img src="https://img.shields.io/badge/release-v0.2.2-green" alt="Latest Release">
+        <img src="https://img.shields.io/badge/release-v0.2.3-green" alt="Latest Release">
     </a>
     <a href="https://pypi.org/project/clonellm/" target="_blank">
         <img src="https://img.shields.io/pypi/v/clonellm.svg" alt="PyPI Version">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "clonellm"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python package to create an AI clone of yourself using LLMs."
 packages = [{ from = "src", include = "clonellm" }]
 include = ["src/clonellm/py.typed"]

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,5 @@ setup(
     ],
     python_requires=">=3.9,<3.13",
     install_requires=requirements,
-    extras_require={"chroma": ["langchain-chroma"], "dev": requirements_dev},
+    extras_require={"chroma": ["langchain-chroma"], "faiss": ["faiss-cpu"], "dev": requirements_dev},
 )

--- a/src/clonellm/__init__.py
+++ b/src/clonellm/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Mehdi Samsami"
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 from .core import CloneLLM
 from .embed import LiteLLMEmbeddings

--- a/src/clonellm/core.py
+++ b/src/clonellm/core.py
@@ -49,7 +49,7 @@ class CloneLLM(LiteLLMMixin):
         user_profile (Optional[UserProfile | dict[str, Any] | str]): The profile of the user to be cloned by the language model. Defaults to None.
         memory (Optional[bool | int]): Maximum number of messages in conversation memory. Defaults to None (or 0) for no memory. -1 or `True` means infinite memory.
         api_key (Optional[str]): The API key to use. Defaults to None.
-        **kwargs: Additional keyword arguments supported by the `langchain_community.chat_models.ChatLiteLLM` class.
+        **kwargs (Any): Additional keyword arguments supported by the `langchain_community.chat_models.ChatLiteLLM` class.
 
     """
 
@@ -142,7 +142,7 @@ class CloneLLM(LiteLLMMixin):
             user_profile (Optional[UserProfile | dict[str, Any] | str]): The profile of the user to be cloned by the language model. Defaults to None.
             memory (Optional[bool | int]): Maximum number of messages in conversation memory. Defaults to None (or 0) for no memory. -1 or `True` means infinite memory.
             api_key (Optional[str]): The API key to use. Defaults to None.
-            **kwargs: Additional keyword arguments supported by the `langchain_community.chat_models.ChatLiteLLM` class.
+            **kwargs (Any): Additional keyword arguments supported by the `langchain_community.chat_models.ChatLiteLLM` class.
 
         Returns:
             CloneLLM: An instance of CloneLLM with Chroma-based retrieval.
@@ -188,7 +188,7 @@ class CloneLLM(LiteLLMMixin):
             user_profile (Optional[UserProfile | dict[str, Any] | str]): The profile of the user to be cloned by the language model. Defaults to None.
             memory (Optional[bool | int]): Maximum number of messages in conversation memory. Defaults to None (or 0) for no memory. -1 or `True` means infinite memory.
             api_key (Optional[str]): The API key to use. Defaults to None.
-            **kwargs: Additional keyword arguments supported by the `langchain_community.chat_models.ChatLiteLLM` class.
+            **kwargs (Any): Additional keyword arguments supported by the `langchain_community.chat_models.ChatLiteLLM` class.
 
         Returns:
             CloneLLM instance using the provided context.

--- a/src/clonellm/embed.py
+++ b/src/clonellm/embed.py
@@ -15,7 +15,7 @@ class LiteLLMEmbeddings(LiteLLMMixin, Embeddings):
         model (str): The embedding model to use.
         api_key (Optional[str]): The API key to use. Defaults to None.
         dimensions (Optional[int]): The number of dimensions the resulting output embeddings should have. Defaults to None.
-        **kwargs: Additional keyword arguments supported by the `litellm.embedding` and `litellm.aembedding` functions.
+        **kwargs (Any): Additional keyword arguments supported by the `litellm.embedding` and `litellm.aembedding` functions.
 
     """
 

--- a/src/clonellm/memory.py
+++ b/src/clonellm/memory.py
@@ -1,4 +1,4 @@
-from typing import Sequence, cast
+from typing import Any, Sequence, cast
 
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import BaseMessage
@@ -35,7 +35,7 @@ class InMemoryHistory(BaseChatMessageHistory, BaseModel):
         self.messages = cast(list[BaseMessage], self._trim_messages(self.messages, self.max_memory_size))
 
     @root_validator
-    def trim_messages_upon_init(cls, values):
+    def _trim_messages_upon_init(cls, values: dict[str, Any]) -> dict[str, Any]:
         values["messages"] = cls._trim_messages(values["messages"], values["max_memory_size"])
         return values
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,8 @@ def random_text(request) -> str:
 
 @pytest.fixture
 def clear_memory_store():
-    # Setup
     clonellm.memory._store = {}
     yield
-    # Teardown
     clonellm.memory._store = {}
 
 


### PR DESCRIPTION
- Add `faiss` to extras in _setup.py_ file
- Add type hints for the `kwargs` argument in `CloneLLM` and `LiteLLMEmbeddings` classes
- Rename the `trim_messages_upon_init` method of `InMemoryHistory` to `_trim_messages_upon_init` to make it an internal method, add type hints for its argument and return
- Bump version to 0.2.3