### PR TITLE
maint: minor maintenance changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 </h4>
 
 ## Introduction
-A minimal Python package that enables you to create an AI clone of yourself using LLMs. Built on top of LiteLLM and LangChain, CloneLLM utilizes the Retrieval-Augmented Generation (RAG) to tailor AI responses as if you are answering the questions.
+CloneLLM is a minimal Python package that enables you to create an AI clone of yourself using LLMs. Built on top of LiteLLM and LangChain, CloneLLM utilizes Retrieval-Augmented Generation (RAG) to tailor AI responses as if you are answering the questions.
 
-You can input texts and documents about yourself — including personal information, professional experience, educational background, etc. — which are then embedded into a vector space for dynamic retrieval. This AI clone can act as a virtual assistant or digital representation, capable of handling queries and tasks in a manner that reflects the your own knowledge, tone, style and mannerisms.
+You can input texts and documents about yourself — including personal information, professional experience, educational background, etc. — which are then embedded into a vector space for dynamic retrieval. This AI clone can act as a virtual assistant or digital representation, capable of handling queries and tasks in a manner that reflects your own knowledge, tone, style, and mannerisms.
 
 ## Installation
 Before installing CloneLLM, make sure you have Python 3.10 or newer installed on your machine.

--- a/examples/advanced_clone.py
+++ b/examples/advanced_clone.py
@@ -3,17 +3,16 @@ import datetime
 from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
 
 from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore, UserProfile
+from examples.const import EXIT_COMMANDS, RESET_MEMORY_COMMANDS
 
 # !pip install clonellm[chroma]
 # !pip install pypdf
 # !pip install unstructured
 
-RESET_MEMORY_COMMANDS = ["reset memory", "clear memory", "clear your memory", "forget everything"]
-EXIT_COMMANDS = ["exit", "quit"]
 MAX_MEMORY_SIZE = 20
 
 
-def main():
+def main() -> None:
     documents = [open("about_me.txt").read()]
     documents += PyPDFLoader("my_cv.pdf").load()
     documents += DirectoryLoader("docs/", glob="**/*.md").load()

--- a/examples/advanced_clone_async.py
+++ b/examples/advanced_clone_async.py
@@ -4,17 +4,16 @@ import datetime
 from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
 
 from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore, UserProfile
+from examples.const import EXIT_COMMANDS, RESET_MEMORY_COMMANDS
 
 # !pip install clonellm[chroma]
 # !pip install pypdf
 # !pip install unstructured
 
-RESET_MEMORY_COMMANDS = ["reset memory", "clear memory", "clear your memory", "forget everything"]
-EXIT_COMMANDS = ["exit", "quit"]
 MAX_MEMORY_SIZE = 20
 
 
-async def main():
+async def main() -> None:
     documents = [open("about_me.txt").read()]
     documents += await PyPDFLoader("my_cv.pdf").aload()
     documents += await DirectoryLoader("docs/", glob="**/*.md").aload()

--- a/examples/clone_with_memory.py
+++ b/examples/clone_with_memory.py
@@ -1,12 +1,10 @@
 from langchain_core.documents import Document
 
 from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore
-
-RESET_MEMORY_COMMANDS = ["reset memory", "clear memory", "clear your memory", "forget everything"]
-EXIT_COMMANDS = ["exit", "quit"]
+from examples.const import EXIT_COMMANDS, RESET_MEMORY_COMMANDS
 
 
-def main():
+def main() -> None:
     documents = [Document(page_content=open("data/about_me.txt").read())]
     embedding = LiteLLMEmbeddings(model="embed-english-light-v3.0")
     clone = CloneLLM(

--- a/examples/clone_with_memory_async.py
+++ b/examples/clone_with_memory_async.py
@@ -3,12 +3,10 @@ import asyncio
 from langchain_core.documents import Document
 
 from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore
-
-RESET_MEMORY_COMMANDS = ["reset memory", "clear memory", "clear your memory", "forget everything"]
-EXIT_COMMANDS = ["exit", "quit"]
+from examples.const import EXIT_COMMANDS, RESET_MEMORY_COMMANDS
 
 
-async def main():
+async def main() -> None:
     documents = [Document(page_content=open("bio.txt").read())]
     embedding = LiteLLMEmbeddings(model="embed-english-light-v3.0")
     clone = CloneLLM(

--- a/examples/const.py
+++ b/examples/const.py
@@ -1,0 +1,3 @@
+RESET_MEMORY_COMMANDS = ["reset memory", "clear memory", "clear your memory", "forget everything"]
+
+EXIT_COMMANDS = ["exit", "quit"]

--- a/examples/fit_and_update.py
+++ b/examples/fit_and_update.py
@@ -16,8 +16,8 @@ from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore
 # !pip install unstructured
 
 
-def main():
-    documents = [
+def main() -> None:
+    documents: list[Document | str] = [
         Document(page_content=open("about_me.txt", "r").read()),
         open("bio.txt", "r").read(),
     ]

--- a/examples/fit_and_update_async.py
+++ b/examples/fit_and_update_async.py
@@ -18,8 +18,8 @@ from clonellm import CloneLLM, LiteLLMEmbeddings, RagVectorStore
 # !pip install unstructured
 
 
-async def main():
-    documents = [
+async def main() -> None:
+    documents: list[Document | str] = [
         Document(page_content=open("about_me.txt", "r").read()),
         open("bio.txt", "r").read(),
     ]

--- a/examples/simple_clone.py
+++ b/examples/simple_clone.py
@@ -1,9 +1,8 @@
 from clonellm import CloneLLM
+from examples.const import EXIT_COMMANDS
 
-EXIT_COMMANDS = ["exit", "quit"]
 
-
-def main():
+def main() -> None:
     documents = [open("about_me.txt").read()]
     clone = CloneLLM(model="gpt-3.5-turbo", documents=documents)
     clone.fit()

--- a/examples/simple_clone_with_embedding.py
+++ b/examples/simple_clone_with_embedding.py
@@ -1,9 +1,8 @@
 from clonellm import CloneLLM, LiteLLMEmbeddings
+from examples.const import EXIT_COMMANDS
 
-EXIT_COMMANDS = ["exit", "quit"]
 
-
-def main():
+def main() -> None:
     documents = [open("about_me.txt").read()]
     embedding = LiteLLMEmbeddings(model="text-embedding-3-small")
     clone = CloneLLM(model="gpt-4o-mini", documents=documents, embedding=embedding)

--- a/examples/simple_clone_with_embedding_async.py
+++ b/examples/simple_clone_with_embedding_async.py
@@ -1,11 +1,10 @@
 import asyncio
 
 from clonellm import CloneLLM, LiteLLMEmbeddings
+from examples.const import EXIT_COMMANDS
 
-EXIT_COMMANDS = ["exit", "quit"]
 
-
-async def main():
+async def main() -> None:
     documents = [open("about_me.txt").read()]
     embedding = LiteLLMEmbeddings(model="text-embedding-3-small")
     clone = CloneLLM(model="gpt-4o-mini", documents=documents, embedding=embedding)

--- a/examples/spacy_embeddings.py
+++ b/examples/spacy_embeddings.py
@@ -22,7 +22,7 @@ class SpacyEmbeddings(Embeddings):
         self._spacy_kwargs = kwargs
         self._internal_init()
 
-    def _internal_init(self):
+    def _internal_init(self) -> None:
         self._nlp: Language
         try:
             self._nlp = spacy.load(self.model, **self._spacy_kwargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -3282,17 +3282,6 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
-name = "types-setuptools"
-version = "69.5.0.20240519"
-description = "Typing stubs for setuptools"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types-setuptools-69.5.0.20240519.tar.gz", hash = "sha256:275fb72048b0203d3fbef268298ea78a0913cd114a74872d93f8638ccc5b7c63"},
-    {file = "types_setuptools-69.5.0.20240519-py3-none-any.whl", hash = "sha256:52b264eff8913b5d85848d83bd98efea935fc6129d681d370eb957783880b720"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -3900,4 +3889,4 @@ faiss = ["faiss-cpu"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "c1c5f2f2e2fcaf690e757b9f82831207e58004cea32714c20032d706086d3d76"
+content-hash = "c7c2386e623f01441004e21a887e19555def34b51f71c97cf89cd4b658871554"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ pytest = "*"
 mypy = "*"
 pytest-asyncio = "*"
 ruff = "<1.0.0"
-types-setuptools = "^69.0.0.20240106"
 pre-commit = "*"
 isort = "*"
 
@@ -41,7 +40,6 @@ namespace_packages = false
 files = ["src/clonellm/**/*.py"]
 check_untyped_defs = true
 disable_error_code = ["empty-body"]
-disallow_untyped_defs = false
 strict = true
 
 [[tool.mypy.overrides]]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,5 @@ pytest
 mypy
 pytest-asyncio
 ruff<1.0.0
-types-setuptools>=69.0.0.20240106,<70.0.0
 pre-commit
 isort

--- a/src/clonellm/_base.py
+++ b/src/clonellm/_base.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from litellm import get_api_key, get_llm_provider
 
@@ -14,11 +14,11 @@ class LiteLLMMixin(metaclass=ABCMeta):
 
     @property
     def _llm_provider(self) -> str:
-        return get_llm_provider(model=self.model)[1]  # type: ignore[no-any-return]
+        return cast(str, get_llm_provider(model=self.model)[1])
 
     @property
-    def _api_key(self):
+    def _api_key(self) -> Optional[str]:
         if self.api_key:
             return self.api_key
         else:
-            return get_api_key(llm_provider=self._llm_provider, dynamic_api_key=self.api_key)
+            return cast(Optional[str], get_api_key(llm_provider=self._llm_provider, dynamic_api_key=self.api_key))


### PR DESCRIPTION
- Remove unused `types-setuptools` from dev dependencies
- Improve typing in the methods of `LiteLLMMixin` class
- Remove `disallow_untyped_defs=false` to enforce typing
- Enhance type hints in example scripts, add a script for constants
- Fix typos in README